### PR TITLE
Fix to use luigi.contrib for s3.

### DIFF
--- a/luigi_td/bulk_import.py
+++ b/luigi_td/bulk_import.py
@@ -6,7 +6,7 @@ import subprocess
 import shutil
 import time
 import luigi
-import luigi.s3
+import luigi.contrib.s3
 import tdclient
 
 from six.moves.urllib.parse import urlparse
@@ -211,7 +211,7 @@ class BulkImport(luigi.Task):
         if isinstance(target, luigi.LocalTarget):
             return os.path.abspath(target.path)
         # S3Target
-        if isinstance(target, luigi.s3.S3Target):
+        if isinstance(target, luigi.contrib.s3.S3Target):
             url = urlparse(target.path)
             return "s3://{aws_access_key_id}:{aws_secret_access_key}@/{bucket}{path}".format(
                 aws_access_key_id = target.fs.s3.aws_access_key_id,

--- a/luigi_td/test_bulk_import.py
+++ b/luigi_td/test_bulk_import.py
@@ -245,8 +245,8 @@ class BulkImportTestCase(TestCase):
     def test_s3_path(self):
         class TestInput(luigi.ExternalTask):
             def output(self):
-                s3client = luigi.s3.S3Client(aws_access_key_id='test-key', aws_secret_access_key='test-secret')
-                return luigi.s3.S3Target('s3://test-bucket/test_input.tsv', client=s3client)
+                s3client = luigi.contrib.s3.S3Client(aws_access_key_id='test-key', aws_secret_access_key='test-secret')
+                return luigi.contrib.s3.S3Target('s3://test-bucket/test_input.tsv', client=s3client)
         class TestBulkImportFromS3Target(TestBulkImport):
             def requires(self):
                 return TestInput()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six>=1.9.0
 boto>=2.36.0
-luigi>=1.1.2,<2.5.0
+luigi>=2.7.0
 jinja2>=2.7.3
 td-client>=0.3.2

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="luigi-td",
-    version='0.6.10.dev0',
+    version='0.7.0.dev0',
     description="Luigi integration for Treasure Data",
     author="Treasure Data, Inc.",
     author_email="support@treasure-data.com",


### PR DESCRIPTION
From luigi 2.7.0, luigi.s3 was moved to luigi.contrib.s3.

https://github.com/spotify/luigi/releases/tag/2.6.0
https://github.com/spotify/luigi/pull/2181

Because, it raise ImportError.

```
root@dd21befb6b50:/# luigi.sh
Traceback (most recent call last):
  File "/opt/xxx/summary.py", line 14, in <module>
    import facebook
  File "/opt/xxx/facebook.py", line 1, in <module>
    import core
  File "/opt/xxx/core.py", line 5, in <module>
    import luigi_td
  File "/usr/local/lib/python3.5/dist-packages/luigi_td/__init__.py", line 1, in <module>
    from luigi_td.bulk_import import BulkImport
  File "/usr/local/lib/python3.5/dist-packages/luigi_td/bulk_import.py", line 9, in <module>
    from luigi import s3
ImportError: cannot import name 's3'
```